### PR TITLE
cpptypes: add TypeOfExprType to recognized c++ type mapping

### DIFF
--- a/dmd2/cpp/cpptypes.cpp
+++ b/dmd2/cpp/cpptypes.cpp
@@ -282,17 +282,8 @@ Type *TypeMapper::FromType::fromTypeUnqual(const clang::Type *T)
             return (pt->ty != Tvalueof) ? pt->referenceTo() : t2;
     }
 
-    if (auto TO = dyn_cast<clang::TypeOfExprType>(T))
-    {
-        if (TO->isSugared())
-            return fromType(TO->desugar());
-        else
-        {
-            ExprMapper em(tm);
-            auto e = em.fromExpression(TO->getUnderlyingExpr());
-            return new TypeTypeof(Loc(), e);
-        }
-    }
+    if (auto TOE = dyn_cast<clang::TypeOfExprType>(T))
+        return fromTypeOfExpr(TOE);
 
     llvm::llvm_unreachable_internal("Unrecognized C++ type");
 }
@@ -1082,6 +1073,21 @@ Type* TypeMapper::FromType::fromTypeDependentTemplateSpecialization(const clang:
         tqual->addInst(tempinst);
 
     return adjustAggregateType(tqual);
+}
+
+Type* TypeMapper::FromType::fromTypeOfExpr(const clang::TypeOfExprType* T)
+{
+    if (T->isSugared())
+        return fromType(T->desugar());
+    else
+    {
+        ExprMapper em(tm);
+        auto e = em.fromExpression(T->getUnderlyingExpr());
+        if (!e)
+            ::error(Loc(), "TypeOfExprType had no underlying type");
+
+        return new TypeTypeof(Loc(), e);
+    }
 }
 
 Type* TypeMapper::FromType::fromTypeDecltype(const clang::DecltypeType* T)

--- a/dmd2/cpp/cpptypes.cpp
+++ b/dmd2/cpp/cpptypes.cpp
@@ -282,6 +282,18 @@ Type *TypeMapper::FromType::fromTypeUnqual(const clang::Type *T)
             return (pt->ty != Tvalueof) ? pt->referenceTo() : t2;
     }
 
+    if (auto TO = dyn_cast<clang::TypeOfExprType>(T))
+    {
+        if (TO->isSugared())
+            return fromType(TO->desugar());
+        else
+        {
+            ExprMapper em(tm);
+            auto e = em.fromExpression(TO->getUnderlyingExpr());
+            return new TypeTypeof(Loc(), e);
+        }
+    }
+
     llvm::llvm_unreachable_internal("Unrecognized C++ type");
 }
 

--- a/dmd2/cpp/cpptypes.h
+++ b/dmd2/cpp/cpptypes.h
@@ -107,6 +107,7 @@ public:
         Type *fromTypeInjectedClassName(const clang::InjectedClassNameType *T);
         Type *fromTypeDependentName(const clang::DependentNameType *T);
         Type *fromTypeDependentTemplateSpecialization(const clang::DependentTemplateSpecializationType *T);
+        Type *fromTypeOfExpr(const clang::TypeOfExprType *T);
         Type *fromTypeDecltype(const clang::DecltypeType *T);
         Type *fromTypePackExpansion(const clang::PackExpansionType *T);
         TypeFunction *fromTypeFunction(const clang::FunctionProtoType *T,


### PR DESCRIPTION
This fixes an issue with std::valarray compilation. Now a small example compiles except for cent/ucent errors due to D not supporting these types.
