### PR TITLE
parse: allow 'function' keyword to propogate through to Calypso

### DIFF
--- a/dmd2/parse.c
+++ b/dmd2/parse.c
@@ -2730,6 +2730,16 @@ Dsymbols *Parser::parseImport()
                 if (token.value == TOKassign)
                 {
                     nextToken();
+
+                    // If we are using an external plugin like C++, then the 'function' TOK needs to be passed
+                    // through to the plugin for processing. Std::function in <functional> relies on this.
+                    // Must also use an alias or D's function keyword will collide and we won't be able to use
+                    // the external 'function' from the plugged in language
+                    if (token.value == TOKfunction && treeId != -1)
+                    {
+                            name = new Identifier("function", TOKidentifier);
+                            token.value = TOKidentifier;
+                    }
                     if (token.value != TOKidentifier)
                     {   error("Identifier expected following %s=", alias->toChars());
                         break;


### PR DESCRIPTION
This change allows <functional>'s 'function' class to get closer to compiling. Usage:

import (C++) std._ : cppfunc = function;

Then we can almost instantiate cppfunc when combined with the member function pointer pull request. This may be useful in other situations as C++ programmers may use 'function' in other cases, as well.
