### PR TITLE
Handle the CXXDependentScopeMemberExpr here.

### DIFF
--- a/dmd2/cpp/cppexpression.cpp
+++ b/dmd2/cpp/cppexpression.cpp
@@ -268,6 +268,49 @@ Expression* ExprMapper::fromExpression(const clang::Expr* E, Type *destType,
         else
             return fromExpression(SNTTP->getReplacement());
     }
+    else if (auto CDSME = dyn_cast<clang::CXXDependentScopeMemberExpr>(E))
+    {
+        Expression *e1 = nullptr;
+        Identifier *ident;
+        ::TemplateInstance *tempinst = nullptr;
+
+        if (auto NNS = CDSME->getQualifier())
+        {
+            auto tqual = TypeMapper::FromType(tymap).fromNestedNameSpecifier(NNS);
+            e1 = new TypeExp(loc, tqual);
+        }
+
+        if (CDSME->getMember().isIdentifier())
+	  {
+            ident = fromIdentifier(CDSME->getMember().getAsIdentifierInfo());
+	  }
+        else
+            assert(false && "Unhandled Member Expr");
+
+        if (CDSME->hasExplicitTemplateArgs())
+        {
+            auto tiargs = fromASTTemplateArgumentListInfo(
+                              CDSME->getExplicitTemplateArgs(), tymap);
+
+            tempinst = new ::TemplateInstance(loc, ident);
+            tempinst->tiargs = tiargs;
+        }
+
+        if (e1)
+        {
+            if (tempinst)
+                return new DotTemplateInstanceExp(loc, e1, tempinst);
+            else
+                return new DotIdExp(loc, e1, ident);
+        }
+        else
+        {
+            if (tempinst)
+                return new TypeExp(loc, new TypeInstance(loc, tempinst));
+            else
+                return new IdentifierExp(loc, ident);
+        }
+    }
     else if (auto DSDR = dyn_cast<clang::DependentScopeDeclRefExpr>(E))
     {
         Expression *e1 = nullptr;

--- a/dmd2/cpp/cppexpression.cpp
+++ b/dmd2/cpp/cppexpression.cpp
@@ -273,24 +273,31 @@ Expression* ExprMapper::fromExpression(const clang::Expr* E, Type *destType,
         Expression *e1 = nullptr;
         Identifier *ident;
         ::TemplateInstance *tempinst = nullptr;
+        TypeQualified *tqual = nullptr;
 
         if (auto NNS = CDSME->getQualifier())
         {
-            auto tqual = TypeMapper::FromType(tymap).fromNestedNameSpecifier(NNS);
+            tqual = TypeMapper::FromType(tymap).fromNestedNameSpecifier(NNS);
             e1 = new TypeExp(loc, tqual);
         }
 
         if (CDSME->getMember().isIdentifier())
-	  {
+        {
             ident = fromIdentifier(CDSME->getMember().getAsIdentifierInfo());
-	  }
+            if (tqual)
+            {
+                tqual->addIdent(ident);
+                auto base = CDSME->getBase();
+                e1 = new DotTypeExp(loc, fromExpression(base, tymap.fromType(base->getType())), new Dsymbol(ident));
+            }
+        }
         else
             assert(false && "Unhandled Member Expr");
 
         if (CDSME->hasExplicitTemplateArgs())
         {
             auto tiargs = fromASTTemplateArgumentListInfo(
-                              CDSME->getExplicitTemplateArgs(), tymap);
+                        CDSME->getExplicitTemplateArgs(), tymap);
 
             tempinst = new ::TemplateInstance(loc, ident);
             tempinst->tiargs = tiargs;


### PR DESCRIPTION
This is quite similar to DependentDeclRefExpr. Compiles a couple of iterator uses for std::array now.
