### PR TITLE
Remove alias that is no longer needed in utility example.

### DIFF
--- a/tests/calypso/libstdc++/utility/utility.d
+++ b/tests/calypso/libstdc++/utility/utility.d
@@ -8,14 +8,14 @@
 modmap (C++) "<utility>";
 
 import std.stdio;
-import (C++) std._ : stlpair = pair;
+import (C++) std.pair;
 import (C++) std._ : stlmakepair = make_pair;
 
 void main()
 {
     writeln("utility compiles");
 
-    auto p = new stlpair!(int, int);
+    auto p = new pair!(int, int);
     p = stlmakepair!(int,int)(10,20);
     writeln("first in pair = ", p.first);
     writeln("second in pair = ", p.second);


### PR DESCRIPTION
I suppose this may need to be reverted when the global namespace works again? Not sure, as make_pair still needs aliasing?
