### PR TITLE
Implement type mapping for VectorType

### DIFF
--- a/dmd2/cpp/cpptypes.cpp
+++ b/dmd2/cpp/cpptypes.cpp
@@ -476,13 +476,10 @@ Type *TypeMapper::FromType::fromTypeComplex(const clang::ComplexType *T)
 
 Type* TypeMapper::FromType::fromTypeVector(const clang::VectorType* T)
 {
-    if (auto CVT = dyn_cast<clang::ExtVectorType>(T))
-        return fromType(CVT->desugar());
+    auto t = fromType(T->getElementType());
+    auto dim = new IntegerExp(T->getNumElements());
 
-    if (T->isSugared())
-        return fromType(T->desugar());
-    else
-        return fromType(T->getElementType());
+    return new TypeSArray(t, dim);
 }
 
 Type* TypeMapper::FromType::fromTypeArray(const clang::ArrayType* T)

--- a/dmd2/cpp/cpptypes.cpp
+++ b/dmd2/cpp/cpptypes.cpp
@@ -479,7 +479,7 @@ Type* TypeMapper::FromType::fromTypeVector(const clang::VectorType* T)
     auto t = fromType(T->getElementType());
     auto dim = new IntegerExp(T->getNumElements());
 
-    return new TypeSArray(t, dim);
+    return new TypeVector(Loc(), new TypeSArray(t, dim));
 }
 
 Type* TypeMapper::FromType::fromTypeArray(const clang::ArrayType* T)

--- a/dmd2/cpp/cpptypes.cpp
+++ b/dmd2/cpp/cpptypes.cpp
@@ -416,6 +416,7 @@ Type *TypeMapper::FromType::fromTypeUnqual(const clang::Type *T)
     TYPEMAP(Decltype)
     TYPEMAP(TypeOfExpr)
     TYPEMAP(PackExpansion)
+    TYPEMAP(Vector)
 #undef TYPEMAP
 
     // Array types
@@ -471,6 +472,17 @@ Type *TypeMapper::FromType::fromTypeComplex(const clang::ComplexType *T)
 
     assert(false && "unknown complex number type");
     return nullptr;
+}
+
+Type* TypeMapper::FromType::fromTypeVector(const clang::VectorType* T)
+{
+    if (auto CVT = dyn_cast<clang::ExtVectorType>(T))
+        return fromType(CVT->desugar());
+
+    if (T->isSugared())
+        return fromType(T->desugar());
+    else
+        return fromType(T->getElementType());
 }
 
 Type* TypeMapper::FromType::fromTypeArray(const clang::ArrayType* T)

--- a/dmd2/cpp/cpptypes.h
+++ b/dmd2/cpp/cpptypes.h
@@ -78,6 +78,7 @@ public:
         Type *fromTypeBuiltin(const clang::BuiltinType *T);
         Type *fromTypeComplex(const clang::ComplexType *T);
         Type *fromTypeArray(const clang::ArrayType *T);
+        Type *fromTypeVector(const clang::VectorType *T);
         Type *fromTypeTypedef(const clang::TypedefType *T);
         Type *fromTypeEnum(const clang::EnumType *T);
         Type *fromTypeRecord(const clang::RecordType *T);


### PR DESCRIPTION
I ran into the need for this when trying to build an opencv example. Now I am running into an operator overload problem (same error for zeromq and a couple STL examples), so it seems that fixing operator overloading is the most pressing matter now.
