### PR TITLE
Update tests 

### DIFF
--- a/tests/calypso/libstdc++/deque/deque.d
+++ b/tests/calypso/libstdc++/deque/deque.d
@@ -16,12 +16,14 @@ void main()
     auto dq2 = new deque!(int)(dq);
     auto dq3 = new deque!(double)(10);
     auto dq4 = new deque!(int);
+    auto dq5 = new deque!(int);
 
     // Fill deque with 10 ints
     writeln("push_back 10 ints onto dq");
     for (int i = 0; i < 10; i++)
     {
         dq.push_back(i);
+        dq5.push_back(i);
     }
 
     // Print out
@@ -80,24 +82,27 @@ void main()
     writeln("dq3 is empty = " ~ (dq3.empty() ? "Yes" : "No"));
     writeln("dq3 size = ", dq3.size());
 
+    dq.assign(10,5);
+    auto it = new deque!(int).iterator;
+
     // FAILURES
+
+    // Assertion `int_regs + sse_regs <= 2' failed !?!?!?
+    //it = dq5.begin();
+    // Idiomatic C++ iterator usage doesn't work yet. See list.d also
+    //for (int i=0; i < dq.size(); it++, i++)
+      //writeln(*it);
 
     // 'no property popFront' here
     //foreach(deq; dq3) {}
 
     //auto second = new deque!(int)(4, 100);
 
-    //dq.assign(10,5);
-
     // Doesn't seem to be picking up all template decls
     //immutable int xx = 9;
     //immutable float yy = 8.1;
     //auto dq5 = new deque!(xx, yy);
 
-    // 'no property begin' - almost seems like multipe args messes 
-    // up the function lookups because .at(int), etc. work?
-    //auto it = dq.begin();
-
-    // 'no property insert'
-    //dq.insert(it, 2, 20);
+    // deque iterators need to work for this to work
+    // dq.insert(it, 2, 20);
 }

--- a/tests/calypso/libstdc++/list/list.d
+++ b/tests/calypso/libstdc++/list/list.d
@@ -10,11 +10,19 @@ modmap (C++) "<list>";
 import std.stdio, std.conv, std.string;
 import (C++) std.list;
 
+bool single_digit (const int value) { return (value<10); }
+
+struct is_odd {
+  bool opCall (const int value) { return (value%2)==1; }
+};
+
 void main()
 {
     auto l = new list!int;
     //auto l1 = new list!(4, 100);  // FAILURE
-    //auto l2 = new list!(l);       // FAILURE
+    auto l2 = new list!(int)(l);
+    auto l3 = new list!int;
+    auto l4 = new list!int;
 
     immutable int x = 11;
     immutable int y = 4;
@@ -29,11 +37,51 @@ void main()
     l.sort();
     writeln("List front after sort is ", l.front());
 
-    /* FAILURE -- Iterators don't work yet
-    auto j = l.begin();
-    for (int i = 0; i < l.size(); i++) 
-    {
-      writeln(j++);
-    }
-    */
+    // FAILURE: the next line causes k++ to fail if the iterator
+    // isn't explicitly initialized like below!
+    // auto k = l.begin();
+
+    auto k = new list!(int).iterator;
+
+    // for(; k != l.end(); k++)
+    // FAILURE: classes.cpp:256: DValue* DtoCastClass(Loc&,
+    // DValue*, Type*): Assertion `to->ty == Tclass' failed
+
+
+    writeln("\nList:");
+    // So we have to use this more laboured method below for now
+    k = l.begin;
+    for (int i=0; i < l.size() ; k++, i++)
+      writeln(*k);
+
+    writeln("\nList2 after swapping in List:");
+    // swap works
+    l2.swap(l);
+    k = l2.begin;
+    for (int i=0; i < l2.size() ; k++, i++)
+      writeln(*k);
+
+    l3.assign(l2.begin(), l2.end());
+
+    writeln("\nList4 after assign from array:");
+    auto arr = [7, 64, 9, 22, 4];
+    l4.assign(arr.ptr, arr.ptr+5);
+    k = l4.begin;
+    for (int i=0; i < l4.size() ; k++, i++)
+      writeln(*k);
+
+
+    writeln("\nList4 after single_digits removed:");
+    bool function(const int) sd = &single_digit;
+    l4.remove_if(sd);
+    k = l4.begin;
+    for (int i=0; i < l4.size() ; k++, i++)
+      writeln(*k);
+
+    // FAILURE: unhandled D->C++ conversion
+    /*is_odd io;
+    bool delegate(const int) iof;
+    iof = &io.opCall;
+    l4.remove_if(iof);*/
+
 }

--- a/tests/calypso/libstdc++/stack/stack.d
+++ b/tests/calypso/libstdc++/stack/stack.d
@@ -17,10 +17,22 @@ import (C++) std.deque;
 void main()
 {
     auto dq = new deque!(int);
+    for (int i = 0;i<10; i++)
+      dq.push_back(i);
+
     //auto v = new vector!(int)(2,200);   //FAILURE
 
     auto st1 = new stack!char;
     auto dq2 = new stack!(int)(dq);
+    //auto st2 = new stack!(int, vector!int);    //FAILURE
 
     writeln("stack appears to work");
+    writeln("empty stack size = ", st1.size());
+    writeln("10 element deque stack size = ", dq2.size());
+
+    for (int i = 0;i<10; i++)
+    {
+        writeln("popping the top of a stack of 10 elements from ordered deque = ", dq2.top());
+        dq2.pop();
+    }
 }

--- a/tests/calypso/libstdc++/vector/vector.d
+++ b/tests/calypso/libstdc++/vector/vector.d
@@ -13,8 +13,10 @@ import (C++) std.vector;
 void main()
 {
     auto v = new vector!char;
+    auto v1 = new vector!char;
 
     v.reserve(10);
+    writeln("vector reserved with size of: ", v.capacity());
 
     foreach (c; "Europa")
         v.push_back(c);
@@ -26,5 +28,37 @@ void main()
     for (int i = 0; i < v.size(); i++)
         reconstruct ~= to!string(v.at(i));
 
+    write("printing vector with writeln: ");
     writeln(reconstruct);
+
+    writeln("vector length is: ", v.size());
+    v.resize(5);
+    writeln("vector length after resize(5): ", v.size());
+
+    writeln("vector capacity = ", v.capacity());
+
+    write("printing vector with iterator: ");
+    auto it = new vector!(char).iterator;
+    it = v.begin();
+    // Idiomatic C++ iterator use isn't working yet...see list.d also
+    for (int i = 0; i < v.size(); it++, i++)
+        write(*it);
+    writeln(*it);
+
+
+    writeln("writing second vector with iterator: ");
+    auto arr = "567";
+    v1.assign(arr.ptr, arr.ptr+3);
+    it = v1.begin;
+    for (int i = 0; i < v.size(); it++, i++)
+        write(*it);
+    writeln(*it);
+
+    // FAILURE
+    // classes.cpp:256: DValue* DtoCastClass(Loc&, DValue*, Type*):
+    // Assertion `to->ty == Tclass' failed.
+    //const char x = '5';
+    //write("inserting character into first vector: ");
+    //it = v.begin();
+    //v.insert(it, x);
 }


### PR DESCRIPTION
Iterators are working for lists and vectors now. This allows functions like assign to work now and remove_if works using a function pointer which is a nice advanced example of Calypso, imo.

There is still a problem with idiomatic C++ usage but you can see the workaround in lists.d. Deque iterators don't work yet either.

Thanks,
Kelly
