### PR TITLE
Change StringLiteral mapping for wide chars and add a test case.

### DIFF
--- a/dmd2/cpp/cppexpression.cpp
+++ b/dmd2/cpp/cppexpression.cpp
@@ -217,12 +217,25 @@ Expression* ExprMapper::fromExpression(const clang::Expr* E, Type *destType,
     }
     else if (auto SL = dyn_cast<clang::StringLiteral>(E))
     {
+        char* data;
         utf8_t postfix = 0;
+
+        data = const_cast<char *>(SL->getBytes().data());
+
         if (SL->getCharByteWidth() == 2)
+	{
             postfix = 'w';
+            return new CastExp(loc, new StringExp(loc, data, SL->getLength(), postfix),
+                               new TypePointer(Type::tint16->constOf()));
+        }
         else if (SL->getCharByteWidth() == 4)
+	{
             postfix = 'd';
-        else assert(SL->getCharByteWidth() == 1);
+            return new CastExp(loc, new StringExp(loc, data, SL->getLength(), postfix),
+                               new TypePointer(Type::tint32->constOf()));
+        }
+        else
+            assert(SL->getCharByteWidth() == 1);
 
         return new StringExp(loc, const_cast<char*>(SL->getString().data()),
                              SL->getLength(), postfix);

--- a/tests/calypso/build.sh
+++ b/tests/calypso/build.sh
@@ -1,3 +1,4 @@
 rm -f calypso_cache* *.o
 clang++ -std=c++11 -c showcase.cpp -o showcase.cpp.o
 ar rcs libshowcase.a showcase.cpp.o
+ldc2 -L-lstdc++ showcase.d -Llibshowcase.a -L-lsupc++

--- a/tests/calypso/showcase.cpp
+++ b/tests/calypso/showcase.cpp
@@ -26,6 +26,11 @@ float testClass::echo2(float f)
     return -1.0;
 }
 
+const wchar_t* testClass::testWideString(const wchar_t* defaultNotFound)
+{
+    return defaultNotFound;
+}
+
 int testInherit::echo(int a, int b)
 {
     return 42 * (a-b) * n;

--- a/tests/calypso/showcase.d
+++ b/tests/calypso/showcase.d
@@ -107,6 +107,7 @@ void main()
     writeln("cls.priv.f = ", cls.priv.f);
     writeln("cls.echo(9, 8) = ", cls.echo(9, 8)); // 42 * 5 == 210 expected if the ctor was called
     writeln("cls.echo2(2.5) = ", cls.echo2(2.5));
+    //writeln("cls.testWideString() = ", cls.testWideString());  // FAILURE
 
     testMultipleInherit mul = new testMultipleInherit;
     mul.pointerToStruct = &cs;

--- a/tests/calypso/showcase.hpp
+++ b/tests/calypso/showcase.hpp
@@ -26,6 +26,7 @@ namespace test {
         unsigned n;
         virtual int echo(int a, int b);
         virtual float echo2(float f);
+        virtual const wchar_t* testWideString(const wchar_t* defaultNotFound = L"unknown");
 
         testClass() { n = 1000; }
     };


### PR DESCRIPTION
I was getting some errors when trying to build a library with something similar to the test case. The mapping seems to work in one direction, but going back from D->C++ still gives an error. The type getting through to cpptypes.cpp(1819):toType is a 'const(int)*' and it appears as though that int is not being seen as a builtin type? The switch(t->ty) will match against a Tint32, which I figured should map easily to a builtin type with toClang[t] in the line above?? Not sure what is going on there.

Thanks,
Kelly
