### PR TITLE
allow passing multiple (space delimited) arguments to -cpp-args;

### DIFF
--- a/ddmd/cpp/calypso.cpp
+++ b/ddmd/cpp/calypso.cpp
@@ -47,7 +47,6 @@
 #include "llvm/Target/TargetMachine.h"
 
 #include <fstream>
-#include <iostream>
 #include <string>
 
 void codegenModules(Modules &modules, bool oneobj);
@@ -847,25 +846,23 @@ void PCH::update()
 
             // NOTE: an alternative would be to use "foo\ bar" for escaping space, but it has other drawbacks, eg for windows, or for escaping '\' itself; also it adds complexity on user shell command. This seems simpler.
 
-            // TODO: is another character more standard and cross-platform?
+            // TODO: is another character more standard and cross-platform (and less susceptible to bash substitution)?
             char single_arg='$';
 
             if(line[0]==single_arg){
-                // TODO: what to do if line.size()=1 ?
-                args.push_back(line.substr(1));
+                if (line.size() > 1)
+                    args.push_back(line.substr(1));
                 continue;
             }
 
-            for(char c : line){
+            for(char c : line)
                 if(c==' '){
                     if(!arg.empty()){
                         args.push_back(arg);
                         arg.clear();
                     }
-                } else {
+                } else
                     arg.push_back(c);
-                }
-            }
 
             if(!arg.empty())
                 args.push_back(arg);

--- a/ddmd/cpp/calypso.cpp
+++ b/ddmd/cpp/calypso.cpp
@@ -860,14 +860,12 @@ void PCH::update()
                 }
             }
 
-            if(!arg.empty()){
+            if(!arg.empty())
                 args.push_back(arg);
-            }
         }
 
-        for(const auto& argi : args){
+        for(const auto& argi : args)
             Argv.push_back(argi.c_str());
-        }
     }
 
     Argv.push_back("-c");
@@ -880,13 +878,13 @@ void PCH::update()
 
     llvm::opt::InputArgList ArgList(Argv.begin(), Argv.end());
 
-    // TODO: is that the right flag to control this?
-    if (opts::cppVerboseDiags){
-        std::cout << "command line args: " << std::endl;
-        for(const auto& ai:Argv){
-            std::cout << " "<< ai << std::endl;
-        }
-        std::cout << std::endl;
+    // MODIF
+    if (global.params.verbose){
+        std::string msg;
+        for(const auto& ai:Argv)
+            msg += "'" + ai + "' ";
+        // 3 spaces to look fine with other -v printed lines
+        fprintf(global.stdmsg, "calypso   clang command line args: %s\n", msg.c_str());
     }
 
     cxxStdlibType = C->getDefaultToolChain().GetCXXStdlibType(ArgList);

--- a/ddmd/cpp/calypso.cpp
+++ b/ddmd/cpp/calypso.cpp
@@ -52,6 +52,12 @@
 
 void codegenModules(Modules &modules, bool oneobj);
 
+void log_verbose(const std::string& header, const std::string& msg){
+    // to look aligned with other -v printed lines
+    int prefix_width=9; // TODO: adjust upwards as needed
+    fprintf(global.stdmsg, "%-*s %s\n", prefix_width, header.c_str(), msg.c_str());
+}
+
 namespace cpp
 {
 
@@ -826,6 +832,7 @@ void PCH::update()
 
     llvm::SmallVector<const char *, 16> Argv;
 
+    // Calypso doesn't call any clang executable, it embeds a clang executable into itself
     Argv.push_back("clang");
     
     // code below needs to push to args instead of directly to Argv otherwise char* pointers get invalidated
@@ -878,13 +885,14 @@ void PCH::update()
 
     llvm::opt::InputArgList ArgList(Argv.begin(), Argv.end());
 
-    // MODIF
     if (global.params.verbose){
-        std::string msg;
-        for(const auto& ai:Argv)
-            msg += "'" + ai + "' ";
-        // 3 spaces to look fine with other -v printed lines
-        fprintf(global.stdmsg, "calypso   clang command line args: %s\n", msg.c_str());
+        std::string msg="clang_args ";
+        for(const auto& ai:Argv){
+            msg += "'";
+            msg += ai;
+            msg += "' ";
+        }
+        log_verbose("calypso", msg);
     }
 
     cxxStdlibType = C->getDefaultToolChain().GetCXXStdlibType(ArgList);

--- a/ddmd/cpp/calypso.cpp
+++ b/ddmd/cpp/calypso.cpp
@@ -47,6 +47,8 @@
 #include "llvm/Target/TargetMachine.h"
 
 #include <fstream>
+#include <iostream>
+#include <string>
 
 void codegenModules(Modules &modules, bool oneobj);
 
@@ -823,9 +825,51 @@ void PCH::update()
     TheDriver.setTitle("Calypso");
 
     llvm::SmallVector<const char *, 16> Argv;
+
     Argv.push_back("clang");
-    for (auto& cppArg: opts::cppArgs)
-        Argv.push_back(cppArg.c_str());
+    
+    // code below needs to push to args instead of directly to Argv otherwise char* pointers get invalidated
+    std::vector<std::string> args;
+
+    {
+        // eg: handle line=" -Ifoo -v " => "-Ifoo", "-v"
+        std::string arg;
+        for (auto& line: opts::cppArgs){
+            arg.clear();
+            if(line.empty()) continue;
+
+            // NOTE: an alternative would be to use "foo\ bar" for escaping space, but it has other drawbacks, eg for windows, or for escaping '\' itself; also it adds complexity on user shell command. This seems simpler.
+
+            // TODO: is another character more standard and cross-platform?
+            char single_arg='$';
+
+            if(line[0]==single_arg){
+                // TODO: what to do if line.size()=1 ?
+                args.push_back(line.substr(1));
+                continue;
+            }
+
+            for(char c : line){
+                if(c==' '){
+                    if(!arg.empty()){
+                        args.push_back(arg);
+                        arg.clear();
+                    }
+                } else {
+                    arg.push_back(c);
+                }
+            }
+
+            if(!arg.empty()){
+                args.push_back(arg);
+            }
+        }
+
+        for(const auto& argi : args){
+            Argv.push_back(argi.c_str());
+        }
+    }
+
     Argv.push_back("-c");
     Argv.push_back("-x");
     Argv.push_back("c++-header");
@@ -835,6 +879,16 @@ void PCH::update()
     assert(C);
 
     llvm::opt::InputArgList ArgList(Argv.begin(), Argv.end());
+
+    // TODO: is that the right flag to control this?
+    if (opts::cppVerboseDiags){
+        std::cout << "command line args: " << std::endl;
+        for(const auto& ai:Argv){
+            std::cout << " "<< ai << std::endl;
+        }
+        std::cout << std::endl;
+    }
+
     cxxStdlibType = C->getDefaultToolChain().GetCXXStdlibType(ArgList);
 
     if (needHeadersReload)

--- a/ddmd/cpp/calypso.h
+++ b/ddmd/cpp/calypso.h
@@ -12,6 +12,7 @@
 #include "../gen/cgforeign.h"
 
 #include <memory>
+#include <string>
 #include "llvm/ADT/StringSet.h"
 #include "llvm/IR/DataLayout.h"
 #include "clang/AST/ASTMutationListener.h"
@@ -316,5 +317,8 @@ cpp::ClassDeclaration *isDCXX(Dsymbol *s);
 
 #define CALYPSO_LANGPLUGIN \
     ::LangPlugin *langPlugin() override { return &calypso; }
+
+// TODO: use this pattern for all global.params.verbose logging; MOVE to root/ddmd/
+void log_verbose(const std::string& header, const std::string& msg);
 
 #endif /* DMD_CPP_CALYPSO_H */

--- a/driver/cl_options.cpp
+++ b/driver/cl_options.cpp
@@ -518,7 +518,7 @@ cl::list<std::string>
 
 // CALYPSO
 cl::list<std::string> cppArgs("cpp-args",
-    cl::desc("Clang arguments passed during PCH generation"));
+    cl::desc("Clang arguments (space separated) passed during PCH generation; if starts with '$', interpret as a single argument"));
 
 cl::opt<std::string> cppCacheDir("cpp-cachedir",
     cl::desc("Write Calypso cache files to <dir>"),


### PR DESCRIPTION
use `$arg with space` to force single arg in case of an arg with spaces

fixes https://github.com/Syniurge/Calypso/issues/75