### PR TITLE
fix https://github.com/Syniurge/Calypso/issues/101

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -556,7 +556,8 @@ set_target_properties(
     ARCHIVE_OUTPUT_NAME ldc
     LIBRARY_OUTPUT_NAME ldc
     RUNTIME_OUTPUT_NAME ldc
-    COMPILE_FLAGS "${LLVM_CXXFLAGS} ${LDC_CXXFLAGS} ${EXTRA_CXXFLAGS}"
+    # -fno-rtti added to avoid Undefined symbols "typeinfo for clang::DiagnosticConsumer" https://github.com/Syniurge/Calypso/pull/104
+    COMPILE_FLAGS "${LLVM_CXXFLAGS} ${LDC_CXXFLAGS} ${EXTRA_CXXFLAGS} -fno-rtti"
     LINK_FLAGS "${SANITIZE_LDFLAGS}"
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -693,6 +693,10 @@ if(LDC_WITH_LLD)
     else()
         set(LDC_LINKERFLAG_LIST "-llldCOFF;-llldCore;-llldDriver;${LDC_LINKERFLAG_LIST}")
     endif()
+    if(APPLE)
+        # fix https://github.com/Syniurge/Calypso/issues/101 OSX build fails after update to llvm 5.0.1
+        set(LDC_LINKERFLAG_LIST "-lc++;${LDC_LINKERFLAG_LIST}")
+    endif()
 endif()
 
 set(LDC_LINK_MANUALLY OFF)

--- a/ddmd/cpp/diagprinter.h
+++ b/ddmd/cpp/diagprinter.h
@@ -47,7 +47,7 @@ class DiagnosticPrinter : public DiagnosticConsumer {
 public:
   DiagnosticPrinter(raw_ostream &os, DiagnosticOptions *diags,
                         bool OwnsOutputStream = false);
-  virtual ~DiagnosticPrinter();
+  ~DiagnosticPrinter() override;
 
   /// setPrefix - Set the diagnostic printer prefix string, which will be
   /// printed at the start of any diagnostics. If empty, no prefix string is


### PR DESCRIPTION
/cc @Syniurge 

fixes https://github.com/Syniurge/Calypso/issues/101 but now getting a (single) undefined error:

Undefined symbols for architecture x86_64:
  "typeinfo for clang::DiagnosticConsumer", referenced from:
      typeinfo for cpp::reclang::DiagnosticPrinter in libldc.a(diagprinter.cpp.o)

when building
/Users/timothee/git_clone/temp/D/Calypso/build_staging_ninja/bin/ldc2


```
cd /Users/timothee/git_clone/temp/D/Calypso && /Users/timothee/homebrew/bin/ldmd2 -wi -O -inline -release -J/Users/timothee/git_clone/temp/D/Calypso/ddmd -J/Users/timothee/git_clone/temp/D/Calypso/res -I/Users/timothee/git_clone/temp/D/Calypso -I/Users/timothee/git_clone/temp/D/Calypso/build_staging_ninja -version=IN_LLVM -of/Users/timothee/git_clone/temp/D/Calypso/build_staging_ninja/bin/ldc2 /Users/timothee/git_clone/temp/D/Calypso/build_staging_ninja/bin/ldc2.o -L/Users/timothee/git_clone/temp/D/Calypso/build_staging_ninja/lib/libldc.a -L/Users/timothee/git_clone/temp/D/Calypso/build_staging_ninja/deps/clang/lib/libclangFrontend.a -L/Users/timothee/git_clone/temp/D/Calypso/build_staging_ninja/deps/clang/lib/libclangDriver.a -L/Users/timothee/git_clone/temp/D/Calypso/build_staging_ninja/deps/clang/lib/libclangCodeGen.a -L/Users/timothee/git_clone/temp/D/Calypso/build_staging_ninja/deps/clang/lib/libclangSerialization.a -L/Users/timothee/git_clone/temp/D/Calypso/build_staging_ninja/deps/clang/lib/libclangSema.a -L/Users/timothee/git_clone/temp/D/Calypso/build_staging_ninja/deps/clang/lib/libclangEdit.a -L/Users/timothee/git_clone/temp/D/Calypso/build_staging_ninja/deps/clang/lib/libclangAnalysis.a -L/Users/timothee/git_clone/temp/D/Calypso/build_staging_ninja/deps/clang/lib/libclangAST.a -L/Users/timothee/git_clone/temp/D/Calypso/build_staging_ninja/deps/clang/lib/libclangParse.a -L/Users/timothee/git_clone/temp/D/Calypso/build_staging_ninja/deps/clang/lib/libclangSema.a -L/Users/timothee/git_clone/temp/D/Calypso/build_staging_ninja/deps/clang/lib/libclangLex.a -L/Users/timothee/git_clone/temp/D/Calypso/build_staging_ninja/deps/clang/lib/libclangBasic.a -L-lc++ -L-llldCOFF -L-llldCore -L-llldDriver -L-lLLVMLTO -L-lLLVMPasses -L-lLLVMObjCARCOpts -L-lLLVMLibDriver -L-lLLVMOption -L-lLLVMDebugInfoPDB -L-lLLVMDebugInfoDWARF -L-lLLVMCoverage -L-lLLVMXCoreDisassembler -L-lLLVMXCoreCodeGen -L-lLLVMXCoreDesc -L-lLLVMXCoreInfo -L-lLLVMXCoreAsmPrinter -L-lLLVMX86Disassembler -L-lLLVMX86AsmParser -L-lLLVMX86CodeGen -L-lLLVMX86Desc -L-lLLVMX86Info -L-lLLVMX86AsmPrinter -L-lLLVMX86Utils -L-lLLVMSystemZDisassembler -L-lLLVMSystemZCodeGen -L-lLLVMSystemZAsmParser -L-lLLVMSystemZDesc -L-lLLVMSystemZInfo -L-lLLVMSystemZAsmPrinter -L-lLLVMSparcDisassembler -L-lLLVMSparcCodeGen -L-lLLVMSparcAsmParser -L-lLLVMSparcDesc -L-lLLVMSparcInfo -L-lLLVMSparcAsmPrinter -L-lLLVMPowerPCDisassembler -L-lLLVMPowerPCCodeGen -L-lLLVMPowerPCAsmParser -L-lLLVMPowerPCDesc -L-lLLVMPowerPCInfo -L-lLLVMPowerPCAsmPrinter -L-lLLVMNVPTXCodeGen -L-lLLVMNVPTXDesc -L-lLLVMNVPTXInfo -L-lLLVMNVPTXAsmPrinter -L-lLLVMMSP430CodeGen -L-lLLVMMSP430Desc -L-lLLVMMSP430Info -L-lLLVMMSP430AsmPrinter -L-lLLVMMipsDisassembler -L-lLLVMMipsCodeGen -L-lLLVMMipsAsmParser -L-lLLVMMipsDesc -L-lLLVMMipsInfo -L-lLLVMMipsAsmPrinter -L-lLLVMLanaiDisassembler -L-lLLVMLanaiCodeGen -L-lLLVMLanaiAsmParser -L-lLLVMLanaiDesc -L-lLLVMLanaiAsmPrinter -L-lLLVMLanaiInfo -L-lLLVMHexagonDisassembler -L-lLLVMHexagonCodeGen -L-lLLVMHexagonAsmParser -L-lLLVMHexagonDesc -L-lLLVMHexagonInfo -L-lLLVMBPFDisassembler -L-lLLVMBPFCodeGen -L-lLLVMBPFDesc -L-lLLVMBPFInfo -L-lLLVMBPFAsmPrinter -L-lLLVMARMDisassembler -L-lLLVMARMCodeGen -L-lLLVMARMAsmParser -L-lLLVMARMDesc -L-lLLVMARMInfo -L-lLLVMARMAsmPrinter -L-lLLVMAMDGPUDisassembler -L-lLLVMAMDGPUCodeGen -L-lLLVMipo -L-lLLVMInstrumentation -L-lLLVMVectorize -L-lLLVMLinker -L-lLLVMIRReader -L-lLLVMAsmParser -L-lLLVMAMDGPUAsmParser -L-lLLVMAMDGPUDesc -L-lLLVMAMDGPUInfo -L-lLLVMAMDGPUAsmPrinter -L-lLLVMAMDGPUUtils -L-lLLVMAArch64Disassembler -L-lLLVMMCDisassembler -L-lLLVMAArch64CodeGen -L-lLLVMGlobalISel -L-lLLVMSelectionDAG -L-lLLVMAsmPrinter -L-lLLVMDebugInfoCodeView -L-lLLVMDebugInfoMSF -L-lLLVMCodeGen -L-lLLVMTarget -L-lLLVMScalarOpts -L-lLLVMInstCombine -L-lLLVMTransformUtils -L-lLLVMBitWriter -L-lLLVMAnalysis -L-lLLVMProfileData -L-lLLVMObject -L-lLLVMBitReader -L-lLLVMCore -L-lLLVMBinaryFormat -L-lLLVMAArch64AsmParser -L-lLLVMMCParser -L-lLLVMAArch64Desc -L-lLLVMAArch64Info -L-lLLVMAArch64AsmPrinter -L-lLLVMMC -L-lLLVMAArch64Utils -L-lLLVMSupport -L-lLLVMDemangle -L-L/Users/timothee/homebrew/Cellar/llvm/5.0.1/lib -L-Wl,-search_paths_first -L-Wl,-headerpad_max_install_names -L-lcurses -L-lz -L-lm

```

could this explain? https://stackoverflow.com/questions/307352/g-undefined-reference-to-typeinfo/4184877#4184877

EDIT:
it worked after adding `-fno-rtti` to build.ninja for build CMakeFiles/LDCShared.dir/ddmd/cpp/diagprinter.cpp.o rule as follows:
```
DEP_FILE = CMakeFiles/LDCShared.dir/ddmd/cpp/diagprinter.cpp.o.d
  FLAGS = -fno-rtti -DDMDV2 -DHAVE_SC_ARG_MAX   -I/Users/timothee/homebrew/Cellar/llvm/5.0.1/
```
obviously not a proper fix since it's autogenerated but it's a start

/cc @Syniurge 

also changed dtor to override (as done in lib/ARCMigrate/ARCMT.cpp:129:3) ; maybe you can check in rest of calypso source code if this change could be made elsewhere; seems necessary IIRC

EDIT: fixed properly(?) by adding -fno-rtti to the right place in CMakeLists.txt
not sure whether this has other negative consequences

NOTE: as it builds (successfully) it shows:
```
ld: warning: direct access in function '___cxx_global_var_init' from file '/Users/timothee/git_clone/temp/D/Calypso/build_staging_ninja/lib/libldc.a(cppmodule.cpp.o)' to global weak symbol 'Array<Module*>::~Array()' from file '/Users/timothee/git_clone/temp/D/Calypso/build_staging_ninja/bin/ldc2.o' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
```
